### PR TITLE
Remove failing tests

### DIFF
--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -37,8 +37,6 @@ test_that('scale_colour_ghibli_d takes name args',{
 })
 
 test_that('scale_colour_ghibli_d fails as expected',{
-  expect_error(base_color_plot + scale_colour_ghibli_d())
-
   throws_error(base_color_plot + scale_colour_ghibli_d(name = 'PonyoMedium', direction = 2))
 })
 
@@ -64,7 +62,5 @@ test_that('scale_fill_ghibli_d takes palette args',{
 })
 
 test_that('scale_fill_ghibli_d fails as expected',{
-  expect_error(base_fill_plot + scale_fill_ghibli_d())
-
   throws_error(base_fill_plot + scale_fill_ghibli_d(name = 'PonyoMedium', direction = 2))
 })


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break ghibli.

This PR fixes failing tests by removing them. For context, we have deprecated the `scale_name` argument and the tests were checking whether an error was throws if the `scale_name` argument is missing. Having a missing `scale_name` field is the new default, so these tests no longer serve their purpose.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help ghibli get out a fix if necessary.